### PR TITLE
Temporary fix for levels with more than 9 sectors

### DIFF
--- a/Segment/Segment.cpp
+++ b/Segment/Segment.cpp
@@ -362,15 +362,18 @@ void Segment::LoadRecordFromConfig()
 }
 
 void Segment::OnLoadObject(CKSTRING filename, BOOL isMap, CKSTRING masterName, CK_CLASSID filterClass,
-                           BOOL addtoscene, BOOL reuseMeshes, BOOL reuseMaterials, BOOL dynamic,
-                           XObjectArray* objArray, CKObject* masterObj) {
+													 BOOL addtoscene, BOOL reuseMeshes, BOOL reuseMaterials, BOOL dynamic,
+													 XObjectArray* objArray, CKObject* masterObj) {
 	if (!isMap)
 		return;
 	ingameparameter_array_ = m_bml->GetArrayByName("IngameParameter");
 	m_bml->GetArrayByName("CurrentLevel")->GetElementValue(0, 0, &current_level_);
 	char buffer[BUF_SIZE];
 	for (int i = 1; i <= 9; i++) {
-		sprintf_s(buffer, "Sector_%02d", i);
+		if (i == 9)
+			strcpy_s(buffer, "Sector_9");
+		else
+			sprintf_s(buffer, "Sector_%02d", i);
 		if (m_bml->GetGroupByName(buffer) == nullptr)
 			break;
 
@@ -512,6 +515,7 @@ void Segment::OnProcess()
 		is_irregular_sector_change = true;
 		OnPreCheckpointReached();
 		is_irregular_sector_change = false;
+		if (next_sector > 10) next_sector = 10;
 		this->current_sector_ = next_sector - 1;
 	}
 
@@ -545,6 +549,7 @@ void Segment::OnStartLevel()
 
 void Segment::OnPreCheckpointReached()
 {
+	if (current_sector_ >= 9) current_sector_ = 8;
 	for (auto& duty_slice : duty_slices_)
 		duty_slice(); // Refreshes last segment on checkpoint reached. Excluding delta cell.(aka. second column)
 
@@ -555,6 +560,7 @@ void Segment::OnPreCheckpointReached()
 	ingameparameter_array_->GetElementValue(0, 1, &this->current_sector_);
 	if (is_irregular_sector_change)
 		current_sector_--;
+	if (current_sector_ > 9) current_sector_ = 9;
 	cursor_->SetPosition(Vx2DVector(0.0f, PANEL_INIT_Y_POS + static_cast<float>(current_sector_) * PANEL_Y_SHIFT));
 
 	sr_time_ = 0;

--- a/Segment/Segment.h
+++ b/Segment/Segment.h
@@ -3,7 +3,7 @@
 #include <sstream>
 constexpr int SEG_MAJOR_VER = 1;
 constexpr int SEG_MINOR_VER = 2;
-constexpr int SEG_PATCH_VER = 6;
+constexpr int SEG_PATCH_VER = 7;
 extern "C" {
 	__declspec(dllexport) IMod* BMLEntry(IBML* bml);
 }


### PR DESCRIPTION
This works by treating every sector above 9 as sector 9 (creating more space for new sectors proved to be problematic, causing y-overflows and lag/freeze the game).
Activating checkpoints above sector 9 still empties the segment panel for some reason. At least it will not crash the entire in-game sector logic now.